### PR TITLE
fix: support MQTT v5 topic subscription format

### DIFF
--- a/src/Metrics/SubscriptionMetrics.php
+++ b/src/Metrics/SubscriptionMetrics.php
@@ -35,8 +35,10 @@ class SubscriptionMetrics extends BaseMetrics
         $this->addToTimestampArray($this->subscriptionTimes, $this->getCurrentTimestamp());
 
         foreach ($topics as $topic => $qos) {
-            $this->recordTopicActivity($topic, $qos);
-            $this->recordQosUsage($qos);
+            // Support both MQTT v3 (int) and v5 (array with 'qos' key) formats
+            $qosValue = is_array($qos) ? ($qos['qos'] ?? 0) : $qos;
+            $this->recordTopicActivity($topic, $qosValue);
+            $this->recordQosUsage($qosValue);
         }
 
         $this->updatePoolStats($poolName, count($topics), true);
@@ -49,7 +51,9 @@ class SubscriptionMetrics extends BaseMetrics
         $this->recordFailure();
 
         foreach ($topics as $topic => $qos) {
-            $this->recordTopicActivity($topic, $qos);
+            // Support both MQTT v3 (int) and v5 (array with 'qos' key) formats
+            $qosValue = is_array($qos) ? ($qos['qos'] ?? 0) : $qos;
+            $this->recordTopicActivity($topic, $qosValue);
         }
 
         $this->updatePoolStats($poolName, 0, false, $reason);


### PR DESCRIPTION
## Summary
- Fixed TypeError when subscribing with MQTT v5 topic format
- Code assumed MQTT v3 format (int QoS) but v5 passes arrays with 'qos' key
- Now supports both formats: `['topic' => 1]` (v3) and `['topic' => ['qos' => 1, ...]]` (v5)

## Fixes
- `SubscriptionMetrics::recordSuccessfulSubscription()` - extract QoS from array
- `SubscriptionMetrics::recordFailedSubscription()` - extract QoS from array
- `OnSubscribeListener::validateSubscribeEvent()` - extract QoS before validation
- `OnSubscribeListener::logSuccessfulSubscription()` - extract QoS for logging

## Test plan
- [ ] Deploy to subscriber server and verify no more TypeError
- [ ] Verify metrics are recorded correctly for both v3 and v5 formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)