### PR TITLE
fix: register MqttDebugCommand in ConfigProvider and fix duplicate options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,12 @@
         "test": "co-phpunit --prepend test/bootstrap.php -c phpunit.xml --colors=always",
         "cs-fix": "php-cs-fixer fix $1",
         "analyse": "phpstan analyse --memory-limit 300M -l 0 -c phpstan.neon ./src",
+        "check-commands": "php scripts/check-command-tests.php",
+        "ci": [
+            "@check-commands",
+            "@analyse",
+            "@test"
+        ],
         "start": "php ./bin/hyperf.php start"
     }
 }

--- a/scripts/check-command-tests.php
+++ b/scripts/check-command-tests.php
@@ -1,0 +1,87 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Architectural Enforcement Script: Command Test Coverage
+ *
+ * This script ensures every Command class in src/Command/ has a corresponding
+ * registration in the integration test's getExpectedCommands() method.
+ *
+ * Run: php scripts/check-command-tests.php
+ * CI Usage: php scripts/check-command-tests.php || exit 1
+ */
+
+$srcCommandDir = __DIR__ . '/../src/Command';
+$integrationTestFile = __DIR__ . '/../test/Cases/Command/CommandRegistrationIntegrationTest.php';
+
+// Find all Command classes in src/Command/
+$commandFiles = glob($srcCommandDir . '/*Command.php');
+
+if ($commandFiles === false || empty($commandFiles)) {
+    echo "✓ No command classes found in src/Command/\n";
+    exit(0);
+}
+
+// Read the integration test file
+if (!file_exists($integrationTestFile)) {
+    echo "✗ Integration test file not found: {$integrationTestFile}\n";
+    echo "  Create it with getExpectedCommands() listing all command classes.\n";
+    exit(1);
+}
+
+$integrationTestContent = file_get_contents($integrationTestFile);
+
+$missingCommands = [];
+$foundCommands = [];
+
+foreach ($commandFiles as $file) {
+    $filename = basename($file, '.php');
+    $className = "Nashgao\\MQTT\\Command\\{$filename}";
+
+    // Check if this class is listed in getExpectedCommands()
+    // Handle both fully qualified and imported class references
+    $patterns = [
+        $className . '::class',           // Fully qualified
+        $filename . '::class',            // Short name with use statement
+    ];
+
+    $found = false;
+    foreach ($patterns as $pattern) {
+        if (strpos($integrationTestContent, $pattern) !== false) {
+            $found = true;
+            break;
+        }
+    }
+
+    if ($found) {
+        $foundCommands[] = $className;
+    } else {
+        $missingCommands[] = $className;
+    }
+}
+
+echo "Command Test Coverage Check\n";
+echo "===========================\n\n";
+
+if (!empty($foundCommands)) {
+    echo "✓ Registered commands (" . count($foundCommands) . "):\n";
+    foreach ($foundCommands as $command) {
+        echo "  - {$command}\n";
+    }
+    echo "\n";
+}
+
+if (!empty($missingCommands)) {
+    echo "✗ Missing from integration test (" . count($missingCommands) . "):\n";
+    foreach ($missingCommands as $command) {
+        echo "  - {$command}\n";
+    }
+    echo "\n";
+    echo "Add these to CommandRegistrationIntegrationTest::getExpectedCommands()\n";
+    exit(1);
+}
+
+echo "✓ All commands are covered by integration tests!\n";
+exit(0);

--- a/src/Command/MqttDebugCommand.php
+++ b/src/Command/MqttDebugCommand.php
@@ -29,8 +29,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Command]
 class MqttDebugCommand extends HyperfCommand
 {
-    protected ?string $signature = 'mqtt:debug {--socket= : Unix socket path} {--filter= : Initial filter expression} {--timeout=30 : Connection timeout in seconds}';
-
     protected string $description = 'Interactive debug shell for monitoring real-time MQTT traffic';
 
     public function __construct(
@@ -42,6 +40,7 @@ class MqttDebugCommand extends HyperfCommand
     public function configure(): void
     {
         parent::configure();
+        $this->setName('mqtt:debug');
         $this->setDescription($this->description);
         $this->addOption('socket', 's', InputOption::VALUE_OPTIONAL, 'Unix socket path (default: from config or /tmp/mqtt-debug.sock)');
         $this->addOption('filter', 'f', InputOption::VALUE_OPTIONAL, 'Initial filter expression (e.g., "topic:sensors/#")');

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nashgao\MQTT;
 
+use Nashgao\MQTT\Command\MqttDebugCommand;
 use Nashgao\MQTT\Debug\DebugTapListener;
 use Nashgao\MQTT\Debug\DebugTapServer;
 use Nashgao\MQTT\Debug\DebugTapStartListener;
@@ -22,6 +23,9 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
+            'commands' => [
+                MqttDebugCommand::class,
+            ],
             'listeners' => [
                 OnSubscribeListener::class,
                 OnPublishListener::class,

--- a/test/Cases/Command/CommandRegistrationIntegrationTest.php
+++ b/test/Cases/Command/CommandRegistrationIntegrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nashgao\MQTT\Test\Cases\Command;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Framework\ApplicationFactory;
+use Hyperf\Testing\TestCase;
+use Nashgao\MQTT\Command\MqttDebugCommand;
+use Nashgao\MQTT\ConfigProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Console\Application;
+
+/**
+ * Integration tests that verify commands are properly registered and discoverable.
+ *
+ * These tests boot the real Hyperf container and verify:
+ * - Commands are registered in ConfigProvider
+ * - Commands can be resolved by the container
+ * - Commands are added to the Symfony Application
+ *
+ * @internal
+ */
+#[CoversClass(MqttDebugCommand::class)]
+#[CoversClass(ConfigProvider::class)]
+class CommandRegistrationIntegrationTest extends TestCase
+{
+    /**
+     * Get all command classes that should be registered.
+     *
+     * This is the source of truth - add new commands here.
+     *
+     * @return array<class-string>
+     */
+    public static function getExpectedCommands(): array
+    {
+        return [
+            MqttDebugCommand::class,
+        ];
+    }
+
+    /**
+     * Test that all expected commands are registered in ConfigProvider.
+     */
+    public function testAllCommandsRegisteredInConfigProvider(): void
+    {
+        $configProvider = new ConfigProvider();
+        $config = $configProvider();
+
+        $this->assertArrayHasKey('commands', $config, 'ConfigProvider missing commands key');
+
+        foreach (self::getExpectedCommands() as $commandClass) {
+            $this->assertContains(
+                $commandClass,
+                $config['commands'],
+                "Command {$commandClass} not registered in ConfigProvider"
+            );
+        }
+    }
+
+    /**
+     * Test that all expected commands can be resolved from the container.
+     *
+     * This catches constructor issues, missing dependencies, and option conflicts.
+     */
+    public function testAllCommandsResolvableFromContainer(): void
+    {
+        foreach (self::getExpectedCommands() as $commandClass) {
+            $command = $this->getContainer()->get($commandClass);
+
+            $this->assertInstanceOf(
+                $commandClass,
+                $command,
+                "Failed to resolve {$commandClass} from container"
+            );
+        }
+    }
+
+    /**
+     * Test that all expected commands have valid names.
+     */
+    public function testAllCommandsHaveValidNames(): void
+    {
+        $expectedNames = [
+            MqttDebugCommand::class => 'mqtt:debug',
+        ];
+
+        foreach ($expectedNames as $commandClass => $expectedName) {
+            $command = $this->getContainer()->get($commandClass);
+
+            $this->assertSame(
+                $expectedName,
+                $command->getName(),
+                "Command {$commandClass} has wrong name"
+            );
+        }
+    }
+
+    /**
+     * Test that commands are discoverable via Hyperf's ApplicationFactory.
+     *
+     * This is the ultimate integration test - it simulates what happens
+     * when you run `php bin/hyperf.php`.
+     */
+    public function testCommandsDiscoverableViaApplicationFactory(): void
+    {
+        // Register the ConfigProvider commands in config
+        $config = $this->getContainer()->get(ConfigInterface::class);
+
+        // Get commands from ConfigProvider
+        $configProvider = new ConfigProvider();
+        $providerConfig = $configProvider();
+
+        // Set commands in config (simulating what Hyperf does during boot)
+        $config->set('commands', $providerConfig['commands'] ?? []);
+
+        // Create the application via factory
+        $factory = new ApplicationFactory();
+        $application = $factory($this->getContainer());
+
+        $this->assertInstanceOf(Application::class, $application);
+
+        // Verify each expected command is in the application
+        foreach (self::getExpectedCommands() as $commandClass) {
+            $command = $this->getContainer()->get($commandClass);
+            $commandName = $command->getName();
+
+            $this->assertTrue(
+                $application->has($commandName),
+                "Command '{$commandName}' ({$commandClass}) not found in Application"
+            );
+        }
+    }
+}

--- a/test/Cases/Command/MqttDebugCommandTest.php
+++ b/test/Cases/Command/MqttDebugCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nashgao\MQTT\Test\Cases\Command;
+
+use Nashgao\MQTT\Command\MqttDebugCommand;
+use Nashgao\MQTT\ConfigProvider;
+use Nashgao\MQTT\Test\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Smoke tests for MqttDebugCommand.
+ *
+ * These tests verify basic command registration and configuration,
+ * catching issues like:
+ * - Missing ConfigProvider registration
+ * - Duplicate option definitions
+ * - Invalid command configuration
+ *
+ * @internal
+ */
+#[CoversClass(MqttDebugCommand::class)]
+class MqttDebugCommandTest extends AbstractTestCase
+{
+    /**
+     * Test that the command can be instantiated without errors.
+     *
+     * This catches duplicate option definitions (signature + configure conflict).
+     */
+    public function testCommandCanBeInstantiated(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $command = new MqttDebugCommand($container);
+
+        $this->assertInstanceOf(MqttDebugCommand::class, $command);
+    }
+
+    /**
+     * Test that the command has the correct name.
+     */
+    public function testCommandHasCorrectName(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $command = new MqttDebugCommand($container);
+
+        $this->assertSame('mqtt:debug', $command->getName());
+    }
+
+    /**
+     * Test that the command has the expected options.
+     */
+    public function testCommandHasExpectedOptions(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $command = new MqttDebugCommand($container);
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('socket'), 'Missing --socket option');
+        $this->assertTrue($definition->hasOption('filter'), 'Missing --filter option');
+        $this->assertTrue($definition->hasOption('timeout'), 'Missing --timeout option');
+        $this->assertTrue($definition->hasOption('format'), 'Missing --format option');
+    }
+
+    /**
+     * Test that options have correct shortcuts.
+     */
+    public function testOptionsHaveCorrectShortcuts(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $command = new MqttDebugCommand($container);
+        $definition = $command->getDefinition();
+
+        $this->assertSame('s', $definition->getOption('socket')->getShortcut());
+        $this->assertSame('f', $definition->getOption('filter')->getShortcut());
+        $this->assertSame('t', $definition->getOption('timeout')->getShortcut());
+    }
+
+    /**
+     * Test that MqttDebugCommand is registered in ConfigProvider.
+     *
+     * This catches the missing 'commands' key issue.
+     */
+    public function testCommandIsRegisteredInConfigProvider(): void
+    {
+        $configProvider = new ConfigProvider();
+        $config = $configProvider();
+
+        $this->assertArrayHasKey('commands', $config, 'ConfigProvider missing commands key');
+        $this->assertContains(
+            MqttDebugCommand::class,
+            $config['commands'],
+            'MqttDebugCommand not registered in ConfigProvider'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fix MqttDebugCommand not discoverable by Hyperf (missing ConfigProvider registration)
- Fix duplicate option definitions causing "socket already exists" error

## Root Cause

1. **ConfigProvider** lacked the `commands` array - Hyperf never discovered the command
2. **MqttDebugCommand** defined options twice (`$signature` + `configure()`) - Symfony Console threw "option already exists"

## Changes

- Add `commands` key to ConfigProvider with MqttDebugCommand
- Remove `$signature` property, use `configure()` exclusively
- Add `setName('mqtt:debug')` in configure() method

## Testing Improvements

- Add smoke tests for command instantiation and options
- Add integration tests for Hyperf container resolution  
- Add enforcement script (`composer check-commands`) to ensure all commands have tests
- Add `composer ci` script for full CI pipeline

## Test Results

```
OK (9 tests, 17 assertions)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)