### PR TITLE
fix: Swoole Unix socket client transport compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-alpha.7] - 2026-02-12
+
+### Fixed
+- **Swoole Unix socket client transport**: Fixed `TypeError: swoole_socket_set_option(): Argument #1 ($socket) must be of type Swoole\Coroutine\Socket, Socket given` when using `mqtt:debug` command in Swoole coroutine context
+  - Created `SwooleUnixSocketTransport` that uses `Swoole\Coroutine\Socket` instead of native PHP sockets
+  - `MqttDebugCommand` now auto-selects the appropriate transport based on Swoole availability
+  - Completes the Swoole socket migration (alpha.6 fixed server-side, this fixes client-side)
+
+### Added
+- Integration tests for `SwooleUnixSocketTransport` verifying coroutine compatibility
+
 ## [0.2.1-alpha.6] - 2026-02-12
 
 ### Fixed

--- a/src/Shell/Transport/SwooleUnixSocketTransport.php
+++ b/src/Shell/Transport/SwooleUnixSocketTransport.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nashgao\MQTT\Shell\Transport;
+
+use NashGao\InteractiveShell\Command\CommandResult;
+use NashGao\InteractiveShell\Message\Message;
+use NashGao\InteractiveShell\Parser\ParsedCommand;
+use NashGao\InteractiveShell\Transport\StreamingTransportInterface;
+use Swoole\Coroutine\Socket;
+
+/**
+ * Swoole-compatible Unix Socket transport for debug shell.
+ *
+ * Uses Swoole\Coroutine\Socket instead of native PHP socket_* functions
+ * to avoid type conflicts when running inside Swoole coroutines.
+ *
+ * Swoole's runtime hooks intercept native socket functions and expect
+ * Swoole\Coroutine\Socket objects, causing TypeError when native
+ * Socket objects are passed.
+ */
+final class SwooleUnixSocketTransport implements StreamingTransportInterface
+{
+    private ?Socket $socket = null;
+
+    private bool $connected = false;
+
+    private bool $streaming = false;
+
+    /** @var callable(Message): void|null */
+    private $messageCallback = null;
+
+    private string $buffer = '';
+
+    public function __construct(
+        private readonly string $socketPath,
+        private readonly float $timeout = 30.0,
+    ) {}
+
+    public function connect(): void
+    {
+        if ($this->socket !== null) {
+            return;
+        }
+
+        $socket = new Socket(AF_UNIX, SOCK_STREAM, 0);
+
+        if (! $socket->connect($this->socketPath, 0, $this->timeout)) {
+            throw new \RuntimeException(
+                "Failed to connect to {$this->socketPath}: " . socket_strerror($socket->errCode)
+            );
+        }
+
+        $this->socket = $socket;
+        $this->connected = true;
+
+        // Drain welcome message from server
+        $this->readLine(2.0);
+    }
+
+    public function disconnect(): void
+    {
+        if ($this->socket !== null) {
+            $this->streaming = false;
+            $this->connected = false;
+            $this->socket->close();
+            $this->socket = null;
+            $this->buffer = '';
+        }
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->socket !== null && $this->connected;
+    }
+
+    public function send(ParsedCommand $command): CommandResult
+    {
+        if ($this->socket === null) {
+            return CommandResult::failure('Not connected');
+        }
+
+        $request = [
+            'type' => 'command',
+            'command' => $command->command,
+            'arguments' => $command->arguments,
+            'options' => $command->options,
+        ];
+
+        $json = json_encode($request, JSON_THROW_ON_ERROR) . "\n";
+        $written = $this->socket->send($json);
+
+        if ($written === false) {
+            if ($this->isDisconnectionError($this->socket->errCode)) {
+                $this->connected = false;
+            }
+            return CommandResult::failure('Failed to send command: ' . socket_strerror($this->socket->errCode));
+        }
+
+        $response = $this->readLine($this->timeout);
+        if ($response === null) {
+            return CommandResult::failure('No response from server');
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+            return CommandResult::fromResponse($data);
+        } catch (\JsonException $e) {
+            return CommandResult::failure("Invalid response: {$e->getMessage()}");
+        }
+    }
+
+    public function ping(): bool
+    {
+        if ($this->socket === null) {
+            return false;
+        }
+
+        $ping = json_encode(['type' => 'ping']) . "\n";
+        $written = $this->socket->send($ping);
+
+        if ($written === false) {
+            return false;
+        }
+
+        $response = $this->readLine(1.0);
+        return $response !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getInfo(): array
+    {
+        return [
+            'type' => 'swoole_unix_socket',
+            'path' => $this->socketPath,
+            'connected' => $this->isConnected(),
+            'streaming' => $this->streaming,
+        ];
+    }
+
+    public function getEndpoint(): string
+    {
+        return "unix://{$this->socketPath}";
+    }
+
+    public function supportsStreaming(): bool
+    {
+        return true;
+    }
+
+    public function sendAsync(ParsedCommand $command): void
+    {
+        if ($this->socket === null) {
+            throw new \RuntimeException('Not connected');
+        }
+
+        $request = [
+            'type' => 'command',
+            'command' => $command->command,
+            'arguments' => $command->arguments,
+            'options' => $command->options,
+            'async' => true,
+        ];
+
+        $json = json_encode($request, JSON_THROW_ON_ERROR) . "\n";
+        $this->socket->send($json);
+    }
+
+    public function receive(float $timeout = -1): ?Message
+    {
+        if ($this->socket === null) {
+            return null;
+        }
+
+        $effectiveTimeout = $timeout >= 0 ? $timeout : $this->timeout;
+        $line = $this->readLine($effectiveTimeout);
+
+        if ($line === null) {
+            return null;
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            return Message::fromArray($data);
+        } catch (\JsonException) {
+            return Message::error("Invalid message format: {$line}");
+        }
+    }
+
+    public function onMessage(callable $callback): void
+    {
+        $this->messageCallback = $callback;
+    }
+
+    /**
+     * Invoke the message callback if set.
+     */
+    public function dispatchMessage(Message $message): void
+    {
+        if ($this->messageCallback !== null) {
+            ($this->messageCallback)($message);
+        }
+    }
+
+    public function startStreaming(): void
+    {
+        if ($this->socket === null) {
+            throw new \RuntimeException('Not connected');
+        }
+
+        $subscribe = json_encode(['type' => 'subscribe']) . "\n";
+        $this->socket->send($subscribe);
+
+        $this->streaming = true;
+    }
+
+    public function stopStreaming(): void
+    {
+        if ($this->socket === null) {
+            return;
+        }
+
+        $unsubscribe = json_encode(['type' => 'unsubscribe']) . "\n";
+        $this->socket->send($unsubscribe);
+
+        $this->streaming = false;
+    }
+
+    public function isStreaming(): bool
+    {
+        return $this->streaming;
+    }
+
+    /**
+     * Read a line from the socket using Swoole's coroutine socket.
+     */
+    private function readLine(float $timeout): ?string
+    {
+        if ($this->socket === null) {
+            return null;
+        }
+
+        $startTime = microtime(true);
+        $maxTime = $startTime + $timeout;
+
+        while (true) {
+            // Check buffer for complete line
+            $newlinePos = strpos($this->buffer, "\n");
+            if ($newlinePos !== false) {
+                $line = substr($this->buffer, 0, $newlinePos);
+                $this->buffer = substr($this->buffer, $newlinePos + 1);
+                return $line;
+            }
+
+            // Check timeout
+            $remaining = $maxTime - microtime(true);
+            if ($remaining <= 0) {
+                return null;
+            }
+
+            // Read more data with remaining timeout
+            /** @var false|string $data */
+            $data = $this->socket->recv(4096, $remaining);
+
+            if ($data === false) {
+                $errCode = $this->socket->errCode;
+                // EAGAIN/EWOULDBLOCK means timeout or no data - not an error
+                if ($errCode === SOCKET_EAGAIN || $errCode === 0) {
+                    continue;
+                }
+                if ($this->isDisconnectionError($errCode)) {
+                    $this->connected = false;
+                }
+                return null;
+            }
+
+            if ($data === '') {
+                // Connection closed
+                $this->connected = false;
+                return null;
+            }
+
+            $this->buffer .= $data;
+        }
+    }
+
+    /**
+     * Check if error code indicates disconnection.
+     */
+    private function isDisconnectionError(int $errCode): bool
+    {
+        // POSIX error codes for various disconnect scenarios
+        return in_array($errCode, [
+            104,  // ECONNRESET (Linux)
+            54,   // ECONNRESET (BSD/macOS)
+            32,   // EPIPE
+            107,  // ENOTCONN (Linux)
+            57,   // ENOTCONN (BSD/macOS)
+        ], true);
+    }
+}

--- a/test/Cases/Shell/Transport/SwooleUnixSocketTransportTest.php
+++ b/test/Cases/Shell/Transport/SwooleUnixSocketTransportTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nashgao\MQTT\Test\Cases\Shell\Transport;
+
+use Nashgao\MQTT\Shell\Transport\SwooleUnixSocketTransport;
+use Nashgao\MQTT\Test\AbstractTestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Socket;
+
+/**
+ * Integration tests for SwooleUnixSocketTransport.
+ *
+ * These tests verify that the transport works correctly inside Swoole
+ * coroutine contexts where native PHP socket functions are hooked.
+ *
+ * The original issue: UnixSocketTransport uses native socket_create() which
+ * returns a PHP Socket object. When Swoole hooks are enabled, socket_set_option()
+ * gets intercepted and calls swoole_socket_set_option() which expects a
+ * Swoole\Coroutine\Socket, causing TypeError.
+ *
+ * Note: Tests run via co-phpunit which already provides a coroutine context.
+ *
+ * @internal
+ * @covers \Nashgao\MQTT\Shell\Transport\SwooleUnixSocketTransport
+ */
+final class SwooleUnixSocketTransportTest extends AbstractTestCase
+{
+    private string $socketPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! extension_loaded('swoole')) {
+            $this->markTestSkipped('Swoole extension required');
+        }
+
+        $this->socketPath = sys_get_temp_dir() . '/mqtt-test-' . uniqid() . '.sock';
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->socketPath) && file_exists($this->socketPath)) {
+            @unlink($this->socketPath);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Test that SwooleUnixSocketTransport can connect inside a coroutine.
+     *
+     * This is the core fix verification: the transport must work inside
+     * Swoole coroutine context without TypeError from socket type mismatch.
+     */
+    public function testConnectAndReceiveDoesNotThrowTypeError(): void
+    {
+        $server = $this->createTestServer();
+
+        // Server coroutine - accept one connection and send messages
+        Coroutine::create(function () use ($server): void {
+            /** @var false|Socket $client */
+            $client = $server->accept(5.0);
+            if ($client !== false) {
+                // Send welcome message (JSON like DebugTapServer does)
+                $welcome = json_encode([
+                    'type' => 'system',
+                    'payload' => 'Welcome',
+                    'source' => 'test',
+                    'timestamp' => date(\DateTimeInterface::ATOM),
+                    'metadata' => [],
+                ]) . "\n";
+                $client->send($welcome);
+
+                // Send a test message after brief delay
+                Coroutine::sleep(0.1);
+                $testMsg = json_encode([
+                    'type' => 'publish',
+                    'payload' => ['topic' => 'test/topic', 'message' => 'hello'],
+                    'source' => 'mqtt',
+                    'timestamp' => date(\DateTimeInterface::ATOM),
+                    'metadata' => [],
+                ]) . "\n";
+                $client->send($testMsg);
+
+                Coroutine::sleep(0.5);
+                $client->close();
+            }
+            $server->close();
+        });
+
+        // Give server time to start listening
+        Coroutine::sleep(0.05);
+
+        // Client - this is where the original bug would trigger TypeError
+        $transport = new SwooleUnixSocketTransport($this->socketPath, 5.0);
+
+        // connect() should not throw TypeError
+        $transport->connect();
+
+        $this->assertTrue($transport->isConnected(), 'Transport should be connected');
+
+        // receive() is where the original bug triggered socket_set_option TypeError
+        $message = $transport->receive(2.0);
+
+        $this->assertNotNull($message, 'Should receive a message');
+        $this->assertSame('publish', $message->type);
+
+        $transport->disconnect();
+    }
+
+    /**
+     * Test that ping works inside coroutine context.
+     */
+    public function testPingWorksInCoroutineContext(): void
+    {
+        $server = $this->createTestServer();
+
+        Coroutine::create(function () use ($server): void {
+            /** @var false|Socket $client */
+            $client = $server->accept(5.0);
+            if ($client !== false) {
+                // Welcome
+                $client->send(json_encode(['type' => 'system', 'payload' => 'Welcome']) . "\n");
+
+                // Wait for ping and respond with pong
+                $data = $client->recv(4096, 2.0);
+                if ($data !== false && $data !== '') {
+                    $client->send(json_encode(['type' => 'pong']) . "\n");
+                }
+
+                Coroutine::sleep(0.5);
+                $client->close();
+            }
+            $server->close();
+        });
+
+        Coroutine::sleep(0.05);
+
+        $transport = new SwooleUnixSocketTransport($this->socketPath, 5.0);
+        $transport->connect();
+
+        $result = $transport->ping();
+
+        $this->assertTrue($result, 'Ping should succeed inside coroutine');
+
+        $transport->disconnect();
+    }
+
+    /**
+     * Test streaming mode works inside coroutine.
+     */
+    public function testStreamingModeInCoroutineContext(): void
+    {
+        $server = $this->createTestServer();
+
+        Coroutine::create(function () use ($server): void {
+            /** @var false|Socket $client */
+            $client = $server->accept(5.0);
+            if ($client !== false) {
+                $client->send(json_encode(['type' => 'system', 'payload' => 'Welcome']) . "\n");
+                // Acknowledge subscribe
+                $client->recv(4096, 1.0);
+                $client->send(json_encode(['type' => 'system', 'payload' => 'Subscribed']) . "\n");
+                // Acknowledge unsubscribe
+                $client->recv(4096, 1.0);
+                $client->send(json_encode(['type' => 'system', 'payload' => 'Unsubscribed']) . "\n");
+                Coroutine::sleep(0.5);
+                $client->close();
+            }
+            $server->close();
+        });
+
+        Coroutine::sleep(0.05);
+
+        $transport = new SwooleUnixSocketTransport($this->socketPath, 5.0);
+        $transport->connect();
+
+        $this->assertFalse($transport->isStreaming());
+
+        $transport->startStreaming();
+        $this->assertTrue($transport->isStreaming());
+
+        $transport->stopStreaming();
+        $this->assertFalse($transport->isStreaming());
+
+        $transport->disconnect();
+    }
+
+    /**
+     * Test getInfo returns correct transport type.
+     */
+    public function testGetInfoReturnsCorrectType(): void
+    {
+        $transport = new SwooleUnixSocketTransport('/tmp/test.sock', 30.0);
+        $info = $transport->getInfo();
+
+        $this->assertSame('swoole_unix_socket', $info['type']);
+        $this->assertSame('/tmp/test.sock', $info['path']);
+        $this->assertFalse($info['connected']);
+        $this->assertFalse($info['streaming']);
+    }
+
+    /**
+     * Test getEndpoint returns correct format.
+     */
+    public function testGetEndpointReturnsUnixUri(): void
+    {
+        $transport = new SwooleUnixSocketTransport('/tmp/test.sock', 30.0);
+
+        $this->assertSame('unix:///tmp/test.sock', $transport->getEndpoint());
+    }
+
+    /**
+     * Test supportsStreaming returns true.
+     */
+    public function testSupportsStreaming(): void
+    {
+        $transport = new SwooleUnixSocketTransport('/tmp/test.sock', 30.0);
+
+        $this->assertTrue($transport->supportsStreaming());
+    }
+
+    /**
+     * Test receive returns null when not connected.
+     */
+    public function testReceiveReturnsNullWhenNotConnected(): void
+    {
+        $transport = new SwooleUnixSocketTransport('/tmp/test.sock', 30.0);
+
+        $result = $transport->receive(0.1);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test isConnected returns false initially.
+     */
+    public function testIsConnectedReturnsFalseInitially(): void
+    {
+        $transport = new SwooleUnixSocketTransport('/tmp/test.sock', 30.0);
+
+        $this->assertFalse($transport->isConnected());
+    }
+
+    /**
+     * Create a test Unix socket server.
+     */
+    private function createTestServer(): Socket
+    {
+        if (file_exists($this->socketPath)) {
+            @unlink($this->socketPath);
+        }
+
+        $server = new Socket(AF_UNIX, SOCK_STREAM, 0);
+
+        if (! $server->bind($this->socketPath)) {
+            $this->fail('Failed to bind server socket: ' . socket_strerror($server->errCode));
+        }
+
+        if (! $server->listen(1)) {
+            $server->close();
+            $this->fail('Failed to listen on server socket: ' . socket_strerror($server->errCode));
+        }
+
+        return $server;
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed `TypeError: swoole_socket_set_option(): Argument #1 ($socket) must be of type Swoole\Coroutine\Socket, Socket given` when using `mqtt:debug` command in Swoole coroutine context
- Created `SwooleUnixSocketTransport` that uses `Swoole\Coroutine\Socket` instead of native PHP sockets
- `MqttDebugCommand` now auto-selects the appropriate transport based on Swoole availability
- Completes the Swoole socket migration (alpha.6 fixed server-side, this fixes client-side)

## Test plan
- [x] Added 8 integration tests verifying coroutine compatibility
- [x] All 323 tests pass
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.ai/code)