### PR TITLE
fix: Hyperf coroutine context compatibility for mqtt:debug command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-alpha.8] - 2026-02-12
+
+### Fixed
+- **Hyperf coroutine context compatibility**: Fixed `Swoole\Error: API must be called in the coroutine` when running `mqtt:debug` command in Hyperf
+  - Changed `MqttDebugCommand` from `execute()` to `handle()` to follow Hyperf's standard pattern
+  - Hyperf automatically wraps `handle()` in coroutine context when `$coroutine = true` (default)
+  - Updated `MqttShellClient` to detect existing coroutine context and avoid nested `\Swoole\Coroutine\run()`
+
 ## [0.2.1-alpha.7] - 2026-02-12
 
 ### Fixed

--- a/src/Command/MqttDebugCommand.php
+++ b/src/Command/MqttDebugCommand.php
@@ -50,8 +50,21 @@ class MqttDebugCommand extends HyperfCommand
         $this->addOption('format', null, InputOption::VALUE_OPTIONAL, 'Output format (compact, table, vertical, json)', 'compact');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): int
+    /**
+     * Execute the command using Hyperf's handle() pattern.
+     *
+     * Hyperf wraps handle() in coroutine context automatically when
+     * $coroutine = true (default), so Swoole\Coroutine\Socket operations work.
+     */
+    public function handle(): int
     {
+        $input = $this->input;
+        $output = $this->output;
+
+        if ($input === null || $output === null) {
+            throw new \RuntimeException('Input and output must be set before calling handle()');
+        }
+
         // Get socket path from option, config, or default
         $socketPath = $this->getSocketPath($input);
         $timeoutOption = $input->getOption('timeout');


### PR DESCRIPTION
## Summary
- Changed `MqttDebugCommand` from `execute()` to `handle()` to follow Hyperf's standard pattern
- Hyperf automatically wraps `handle()` in coroutine context when `$coroutine = true` (default)
- Updated `MqttShellClient` to detect existing coroutine context and avoid nested `\Swoole\Coroutine\run()`

## Problem
Running `mqtt:debug` command in Hyperf threw:
```
Swoole\Error: API must be called in the coroutine
```

## Root Cause
`MqttDebugCommand` was overriding `execute()` directly, bypassing Hyperf's coroutine wrapping mechanism. Hyperf's `Command` class wraps the `handle()` method (not `execute()`) in coroutine context.

## Test plan
- [x] PHPStan passes
- [x] All 323 tests pass
- [ ] Manual test in consumer project

🤖 Generated with [Claude Code](https://claude.ai/code)