### PR TITLE
fix: debug shell subscribe event array-to-string conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-alpha.9] - 2026-02-16
+
+### Fixed
+- **Debug shell subscribe event display**: Fixed "Array to string conversion" warning when displaying subscribe events in `mqtt:debug` shell
+  - Subscribe topics format uses topic names as array keys (e.g., `['sensors/#' => ['qos' => 1]]`)
+  - `extractSubscribeTopics()` now correctly uses `array_keys()` to extract topic names
+
 ## [0.2.1-alpha.8] - 2026-02-12
 
 ### Fixed

--- a/src/Shell/Formatter/MqttMessageFormatter.php
+++ b/src/Shell/Formatter/MqttMessageFormatter.php
@@ -511,7 +511,9 @@ final class MqttMessageFormatter
     {
         if (is_array($message->payload) && isset($message->payload['topics'])) {
             $topics = $message->payload['topics'];
-            return is_array($topics) ? array_map('strval', $topics) : [];
+            // Topics format: ['topic/name' => qos] or ['topic/name' => ['qos' => 1, ...]]
+            // Topic names are the keys, not the values
+            return is_array($topics) ? array_map('strval', array_keys($topics)) : [];
         }
         return [];
     }


### PR DESCRIPTION
## Summary
- Fixed "Array to string conversion" warning when displaying subscribe events in `mqtt:debug` shell
- Subscribe topics format uses topic names as array keys (e.g., `['sensors/#' => ['qos' => 1]]`)
- `extractSubscribeTopics()` now correctly uses `array_keys()` to extract topic names

## Test plan
- [x] PHPStan passes
- [ ] Run `mqtt:debug` and trigger a subscribe event - should display topic names correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)