### PR TITLE
feat: add verbose debug logging and fix MQTT v5 topic alias handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-alpha.10] - 2026-02-17
+
+### Fixed
+- **MQTT v5 topic alias handling**: Debug shell no longer silently drops messages when topic is null/empty (MQTT v5 topic alias feature)
+  - Shows `(alias:X)` when topic alias is used
+  - Shows `(unknown)` as fallback instead of dropping the message
+
+### Added
+- **Verbose debug logging**: New `MQTT_DEBUG_VERBOSE=true` config option to trace debug tap event flow
+  - Logs event reception, processing, and broadcast operations
+  - Helps diagnose issues with message not appearing in debug shell
+
 ## [0.2.1-alpha.9] - 2026-02-16
 
 ### Fixed

--- a/publish/mqtt.php
+++ b/publish/mqtt.php
@@ -47,6 +47,7 @@ return [
         // Debug tap configuration for real-time message streaming
         'debug' => [
             'enabled' => env('MQTT_DEBUG_ENABLED', false),
+            'verbose' => env('MQTT_DEBUG_VERBOSE', false), // Enable verbose logging for debugging event flow
             'socket_path' => env('MQTT_DEBUG_SOCKET', '/tmp/mqtt-debug.sock'),
             // Shell-specific configuration
             'shell' => [


### PR DESCRIPTION
## Summary
- Add `MQTT_DEBUG_VERBOSE=true` config option to trace debug tap event flow
- Fix silent message dropping when topic is null/empty (MQTT v5 topic alias)
- Show `(alias:X)` or `(unknown)` instead of dropping messages without topic
- Log event reception, processing, and broadcast operations in verbose mode

## Changes
- `src/Debug/DebugTapListener.php` - Add verbose logging, handle null/empty topics
- `src/Debug/DebugTapServer.php` - Add `logVerbose()` method and `verbose` config
- `publish/mqtt.php` - Add `MQTT_DEBUG_VERBOSE` config option

## Test plan
- [ ] Set `MQTT_DEBUG_VERBOSE=true` in .env
- [ ] Run mqtt:debug and verify verbose logs appear in Hyperf stdout
- [ ] Test with MQTT v5 messages that may have null topics
- [ ] Verify messages now display instead of being silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)