### PR TITLE
fix: prevent coroutine race condition in DebugTapServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-alpha.11] - 2026-02-17
+
+### Fixed
+- **Critical: Coroutine race condition in DebugTapServer**: Fixed `Socket already bound to another coroutine` error when multiple MQTT events fire simultaneously
+  - Added guard flag to prevent concurrent `tick()` calls from multiple coroutines
+  - This was causing subscriber disconnects due to unhandled exceptions
+
 ## [0.2.1-alpha.10] - 2026-02-17
 
 ### Fixed


### PR DESCRIPTION
## Summary
Fixed critical bug causing `Socket already bound to another coroutine` error.

When multiple MQTT events fire simultaneously from different coroutines, they all call `tick()` which tries to `accept()` on the same socket. This caused Swoole to throw an exception, crashing the worker and disconnecting MQTT subscribers.

## Fix
Added a `$ticking` guard flag to prevent concurrent `tick()` calls.

## Test plan
- [ ] Start server with high message volume
- [ ] Verify no more "Socket already bound" errors
- [ ] Verify subscribers stay connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)