### PR TITLE
fix: multi-worker debug tap relay and socket permissions

### DIFF
--- a/docs/plans/2026-02-26-shell-prompt-design.md
+++ b/docs/plans/2026-02-26-shell-prompt-design.md
@@ -1,0 +1,101 @@
+# MQTT Shell Prompt Design
+
+**Date:** 2026-02-26
+**Status:** Approved
+**Complexity:** Simple (~25 lines)
+
+## Problem
+
+The MQTT debug shell has no visible prompt indicator, causing:
+1. **"Is it ready?"** - Uncertainty whether the shell is waiting for input
+2. **"Where am I?"** - When messages scroll by, losing track of the input line
+
+## Solution
+
+Implement a "status line with re-prompt" approach that displays `mqtt> ` at strategic moments.
+
+## Core Behavior
+
+The prompt appears in three situations:
+
+1. **After welcome message** - When shell starts, print `mqtt> ` so user knows it's ready
+2. **After command execution** - When a command completes, re-print the prompt
+3. **After quiet period** - If messages stop for 2+ seconds, print the prompt
+
+### What happens during message flow
+- Messages continue to display normally
+- The prompt does NOT interrupt mid-stream
+- Only appears after natural pauses
+- If user is typing when quiet-period would fire, prompt is suppressed
+
+## Implementation
+
+### Files Changed
+
+1. `src/Shell/MqttShellClient.php` - Add prompt display logic (~20 lines)
+2. `src/Shell/Config/ShellConfig.php` - Add configuration options (~5 lines)
+
+### New State Tracking
+
+```php
+private float $lastActivityTime = 0.0;
+private const QUIET_THRESHOLD = 2.0; // seconds
+```
+
+### Prompt Display Points
+
+1. **After welcome** (in `run()` method):
+   ```php
+   $output->write($this->prompt);
+   ```
+
+2. **After command execution** (end of `handleInput()`):
+   ```php
+   $output->write($this->prompt);
+   ```
+
+3. **Quiet-period check** (in message display coroutine):
+   - Track `$lastActivityTime` when messages display
+   - Check if `time() - $lastActivityTime > QUIET_THRESHOLD`
+   - If quiet and not paused, print prompt
+
+### Configuration Options
+
+```php
+// In ShellConfig.php
+public bool $showPrompt = true,
+public float $promptQuietThreshold = 2.0,
+```
+
+## Design Decisions
+
+### Why not a fixed bottom bar?
+More complex (~50-80 lines), terminal compatibility concerns, potential conflict with readline.
+
+### Why not startup-only prompt?
+Only solves "is it ready?" at startup, not during extended use.
+
+### Why 2 seconds for quiet threshold?
+Balances responsiveness with avoiding prompt spam during bursty message patterns. Configurable if needed.
+
+## Usage
+
+Default behavior - works out of the box:
+```php
+$shell = new MqttShellClient($transport);
+// Prompt appears automatically
+```
+
+Custom configuration:
+```php
+$config = ShellConfig::fromArray([
+    'showPrompt' => true,
+    'promptQuietThreshold' => 3.0,
+]);
+$shell = new MqttShellClient($transport, 'mqtt> ', [], $config);
+```
+
+Disable prompt (for scripting):
+```php
+$config = ShellConfig::fromArray(['showPrompt' => false]);
+```

--- a/src/Debug/DebugTapListener.php
+++ b/src/Debug/DebugTapListener.php
@@ -48,13 +48,15 @@ final class DebugTapListener implements ListenerInterface
             return;
         }
 
-        if (! $this->server->isRunning()) {
-            $this->server->logVerbose('Server not running, skipping event');
+        if (! $this->server->isActive()) {
+            $this->server->logVerbose('Server not active, skipping event');
             return;
         }
 
-        // Process pending connections and commands
-        $this->server->tick();
+        // Only tick (accept connections, process commands) on the worker owning the socket
+        if ($this->server->isRunning()) {
+            $this->server->tick();
+        }
 
         $clientCount = $this->server->getClientCount();
         $this->server->logVerbose("Processing event, connected clients: {$clientCount}");

--- a/src/Debug/DebugTapServer.php
+++ b/src/Debug/DebugTapServer.php
@@ -9,6 +9,7 @@ use Hyperf\Contract\StdoutLoggerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Swoole\Coroutine\Socket;
+use Swoole\Server;
 
 /**
  * Unix socket server for broadcasting MQTT messages to debug shell clients.
@@ -53,6 +54,10 @@ final class DebugTapServer
     private bool $ticking = false;
 
     private ?int $timerId = null;
+
+    private ?int $workerId = null;
+
+    private ?Server $swooleServer = null;
 
     /**
      * Callback for executing MQTT commands from the shell.
@@ -145,6 +150,7 @@ final class DebugTapServer
         }
 
         $this->serverSocket = $socket;
+        chmod($this->socketPath, 0666);
         $this->running = true;
 
         $this->timerId = \Swoole\Timer::tick(100, function (): void {
@@ -324,6 +330,72 @@ final class DebugTapServer
     public function getSocketPath(): string
     {
         return $this->socketPath;
+    }
+
+    /**
+     * Set worker context for multi-worker relay support.
+     *
+     * On worker 0, the server owns the Unix socket and broadcasts directly.
+     * On other workers, events are relayed to worker 0 via Swoole PipeMessage.
+     */
+    public function setWorkerContext(int $workerId, Server $swooleServer): void
+    {
+        $this->workerId = $workerId;
+        $this->swooleServer = $swooleServer;
+    }
+
+    /**
+     * Check if the server can handle events (either direct broadcast or relay).
+     *
+     * Returns true if:
+     * - The socket server is running (worker 0), OR
+     * - The server is in relay mode (non-zero worker with Swoole server context)
+     */
+    public function isActive(): bool
+    {
+        if ($this->running) {
+            return true;
+        }
+
+        return $this->enabled
+            && $this->workerId !== null
+            && $this->workerId !== 0
+            && $this->swooleServer !== null;
+    }
+
+    /**
+     * Handle a PipeMessage that may contain a relayed debug tap event.
+     *
+     * Called on worker 0 when another worker relays an MQTT event via sendMessage().
+     * Non-relay messages are silently ignored.
+     */
+    public function handlePipeMessage(mixed $data): void
+    {
+        if (! $this->running || ! is_string($data)) {
+            return;
+        }
+
+        try {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return;
+        }
+
+        if (! is_array($decoded) || ! isset($decoded['__debug_tap_relay'])) {
+            return;
+        }
+
+        $eventData = $decoded['data'] ?? null;
+        if (! is_array($eventData)) {
+            return;
+        }
+
+        $this->logVerbose('Received relayed event from another worker', [
+            'type' => $eventData['type'] ?? 'unknown',
+        ]);
+
+        $this->broadcastToClients($eventData);
     }
 
     /**
@@ -591,11 +663,51 @@ final class DebugTapServer
     }
 
     /**
-     * Broadcast data to all connected clients.
+     * Broadcast data to all connected clients, or relay to worker 0 if on another worker.
      *
      * @param array<string, mixed> $data
      */
     private function broadcast(array $data): void
+    {
+        // Non-zero workers relay to worker 0 via PipeMessage
+        if ($this->workerId !== null && $this->workerId !== 0) {
+            $this->relayToWorkerZero($data);
+            return;
+        }
+
+        $this->broadcastToClients($data);
+    }
+
+    /**
+     * Relay event data to worker 0 via Swoole PipeMessage.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function relayToWorkerZero(array $data): void
+    {
+        $server = $this->swooleServer;
+        if ($server === null) {
+            return;
+        }
+
+        $payload = json_encode([
+            '__debug_tap_relay' => true,
+            'data' => $data,
+        ], JSON_THROW_ON_ERROR);
+
+        $this->logVerbose("Relaying event from worker {$this->workerId} to worker 0", [
+            'type' => $data['type'] ?? 'unknown',
+        ]);
+
+        $server->sendMessage($payload, 0);
+    }
+
+    /**
+     * Broadcast data directly to all connected socket clients.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function broadcastToClients(array $data): void
     {
         if (! $this->running) {
             $this->logVerbose('broadcast: server not running, skipping');

--- a/src/Debug/DebugTapStartListener.php
+++ b/src/Debug/DebugTapStartListener.php
@@ -6,12 +6,13 @@ namespace Nashgao\MQTT\Debug;
 
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\AfterWorkerStart;
+use Hyperf\Framework\Event\OnPipeMessage;
 
 /**
- * Starts the DebugTapServer when a Hyperf worker starts.
+ * Manages DebugTapServer lifecycle across Swoole workers.
  *
- * This listener is responsible for initializing the debug tap Unix socket server
- * so that debug clients can connect and receive MQTT message streams.
+ * - Worker 0: starts the Unix socket server and handles relayed events from other workers.
+ * - Workers 1+: store Swoole server context so events can be relayed to worker 0 via PipeMessage.
  */
 final class DebugTapStartListener implements ListenerInterface
 {
@@ -26,12 +27,24 @@ final class DebugTapStartListener implements ListenerInterface
     {
         return [
             AfterWorkerStart::class,
+            OnPipeMessage::class,
         ];
     }
 
     public function process(object $event): void
     {
-        // Start the debug tap server (will check if enabled internally)
-        $this->server->start();
+        if ($event instanceof AfterWorkerStart) {
+            $this->server->setWorkerContext($event->workerId, $event->server);
+
+            if ($event->workerId === 0) {
+                $this->server->start();
+            }
+
+            return;
+        }
+
+        if ($event instanceof OnPipeMessage) {
+            $this->server->handlePipeMessage($event->data);
+        }
     }
 }

--- a/src/Shell/Config/ShellConfig.php
+++ b/src/Shell/Config/ShellConfig.php
@@ -33,6 +33,8 @@ final readonly class ShellConfig
      * @param float $activityTimeoutSeconds Timeout for activity detection
      * @param string $historyFile Path to readline history file
      * @param int $historyMaxEntries Maximum entries in readline history
+     * @param bool $showPrompt Whether to display the prompt indicator
+     * @param float $promptQuietThreshold Seconds of quiet before re-displaying prompt
      */
     public function __construct(
         // Message handling
@@ -67,6 +69,10 @@ final readonly class ShellConfig
         // Readline/History
         public string $historyFile = '~/.mqtt_shell_history',
         public int $historyMaxEntries = 1000,
+
+        // Prompt behavior
+        public bool $showPrompt = true,
+        public float $promptQuietThreshold = 2.0,
     ) {}
 
     /**
@@ -106,6 +112,8 @@ final readonly class ShellConfig
             activityTimeoutSeconds: self::getFloat($config, 'activityTimeoutSeconds', 60.0),
             historyFile: self::getString($config, 'historyFile', '~/.mqtt_shell_history'),
             historyMaxEntries: self::getInt($config, 'historyMaxEntries', 1000),
+            showPrompt: self::getBool($config, 'showPrompt', true),
+            promptQuietThreshold: self::getFloat($config, 'promptQuietThreshold', 2.0),
         );
     }
 
@@ -134,6 +142,15 @@ final readonly class ShellConfig
     {
         $value = $config[$key] ?? $default;
         return is_string($value) ? $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private static function getBool(array $config, string $key, bool $default): bool
+    {
+        $value = $config[$key] ?? $default;
+        return is_bool($value) ? $value : $default;
     }
 
     /**
@@ -185,6 +202,8 @@ final readonly class ShellConfig
             'activityTimeoutSeconds' => $this->activityTimeoutSeconds,
             'historyFile' => $this->historyFile,
             'historyMaxEntries' => $this->historyMaxEntries,
+            'showPrompt' => $this->showPrompt,
+            'promptQuietThreshold' => $this->promptQuietThreshold,
         ];
     }
 }

--- a/src/Shell/MqttShellClient.php
+++ b/src/Shell/MqttShellClient.php
@@ -85,6 +85,10 @@ final class MqttShellClient
 
     private bool $verticalFormat = false;
 
+    private float $lastMessageTime = 0.0;
+
+    private bool $promptDisplayed = false;
+
     /**
      * @param array<string, string> $defaultAliases
      * @param ShellConfig|null $config Shell configuration (uses defaults if null)
@@ -130,6 +134,9 @@ final class MqttShellClient
         foreach ($this->getWelcomeLines() as $line) {
             $output->writeln($line);
         }
+
+        // Show initial prompt
+        $this->showPrompt($output);
 
         // Fallback to polling mode
         return $this->runPolling($output);
@@ -336,6 +343,9 @@ final class MqttShellClient
             $output->writeln($line);
         }
 
+        // Show initial prompt
+        $this->showPrompt($output);
+
         // Start streaming (uses socket->send, must be in coroutine)
         $this->transport->startStreaming();
 
@@ -381,6 +391,9 @@ final class MqttShellClient
 
         // Wait for exit
         while ($this->running) {
+            // Check for quiet period - show prompt if messages stopped
+            $this->checkQuietPeriod($output);
+
             // @phpstan-ignore-next-line (Swoole class only available when ext-swoole is loaded)
             \Swoole\Coroutine::sleep(0.1);
         }
@@ -419,6 +432,9 @@ final class MqttShellClient
                 $this->handleInput($line, $output);
             }
 
+            // Check for quiet period - show prompt if messages stopped
+            $this->checkQuietPeriod($output);
+
             // Small delay to prevent CPU spinning
             usleep(10000); // 10ms
         }
@@ -435,8 +451,12 @@ final class MqttShellClient
      */
     private function handleInput(string $line, OutputInterface $output): void
     {
+        // User typed something, so prompt is no longer displayed
+        $this->promptDisplayed = false;
+
         $line = trim($line);
         if ($line === '') {
+            $this->showPrompt($output);
             return;
         }
 
@@ -455,13 +475,18 @@ final class MqttShellClient
             // Check for exit request
             if ($result->shouldExit ?? false) {
                 $this->running = false;
+                return;
             }
+
+            // Show prompt after command completes
+            $this->showPrompt($output);
             return;
         }
 
         // Unknown command
         $output->writeln("<error>Unknown command: {$command}</error>");
         $output->writeln("Type 'help' for available commands");
+        $this->showPrompt($output);
     }
 
     /**
@@ -547,6 +572,8 @@ final class MqttShellClient
         // Display (only if not paused)
         if (!$this->paused) {
             $output->writeln($formatted);
+            $this->lastMessageTime = microtime(true);
+            $this->promptDisplayed = false;
         }
     }
 
@@ -621,6 +648,34 @@ final class MqttShellClient
             'Session ended. Total messages: %d',
             $this->stats->getTotalMessages()
         ));
+    }
+
+    /**
+     * Display the prompt if enabled and not already displayed.
+     */
+    private function showPrompt(OutputInterface $output): void
+    {
+        if (!$this->config->showPrompt || $this->promptDisplayed) {
+            return;
+        }
+
+        $output->write($this->prompt);
+        $this->promptDisplayed = true;
+    }
+
+    /**
+     * Check if messages have been quiet long enough to show the prompt.
+     */
+    private function checkQuietPeriod(OutputInterface $output): void
+    {
+        if ($this->paused || $this->lastMessageTime === 0.0) {
+            return;
+        }
+
+        $quietDuration = microtime(true) - $this->lastMessageTime;
+        if ($quietDuration >= $this->config->promptQuietThreshold) {
+            $this->showPrompt($output);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Worker 0 owns the Unix socket and broadcasts directly; other workers relay events via Swoole PipeMessage — fixes silent event drops in multi-worker deployments
- Socket permissions set to `0666` after bind so non-root users can connect without manual `chmod` after each restart
- `DebugTapListener` uses `isActive()` gate to allow relay workers to pass events through

## Test plan
- [ ] Start MQTT subscriber with `worker_num > 1`, verify debug shell receives events from all workers
- [ ] Restart server as root, connect debug shell as non-root user without manual chmod
- [ ] Verify worker 0 logs show relayed events from other workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)