### PR TITLE
fix: QoS handshake packet consumption + resubscription on disconnect

### DIFF
--- a/src/ClientProxy.php
+++ b/src/ClientProxy.php
@@ -95,7 +95,7 @@ class ClientProxy extends Client
                 $message = parent::recv();
                 // Send ping if keepAlive seconds have passed since last ping
                 if ((time() - $this->timeSincePing) >= $this->config->clientConfig->getKeepAlive()) {
-                    if (parent::ping()) {
+                    if (parent::ping(false)) {
                         $this->timeSincePing = time();
                     } else {
                         return $cont->push(false);
@@ -105,12 +105,12 @@ class ClientProxy extends Client
                 if (! is_bool($message)) {
                     /* qos 1 puback */
                     if ($message['type'] === Types::PUBLISH && $message['qos'] === Qos::QOS_AT_LEAST_ONCE) {
-                        parent::send(['type' => Types::PUBACK, 'message_id' => $message['message_id']]);
+                        parent::send(['type' => Types::PUBACK, 'message_id' => $message['message_id']], false);
                     }
 
                     /* qos 2 pubrel */
                     if ($message['type'] === Types::PUBLISH && $message['qos'] === Qos::QOS_EXACTLY_ONCE) {
-                        parent::send(['type' => Types::PUBREC, 'message_id' => $message['message_id']]);
+                        parent::send(['type' => Types::PUBREC, 'message_id' => $message['message_id']], false);
                     }
 
                     /* qos 2 pub comp */
@@ -119,7 +119,8 @@ class ClientProxy extends Client
                             [
                                 'type' => Types::PUBCOMP,
                                 'message_id' => $message['message_id'],
-                            ]
+                            ],
+                            false
                         );
                     }
 

--- a/src/Debug/DebugTapServer.php
+++ b/src/Debug/DebugTapServer.php
@@ -150,7 +150,7 @@ final class DebugTapServer
         }
 
         $this->serverSocket = $socket;
-        chmod($this->socketPath, 0666);
+        @chmod($this->socketPath, 0666);
         $this->running = true;
 
         $this->timerId = \Swoole\Timer::tick(100, function (): void {
@@ -470,7 +470,7 @@ final class DebugTapServer
 
             if ($data === false) {
                 // Check if it's a real error or just timeout (EAGAIN)
-                if ($client->errCode !== SOCKET_EAGAIN && $client->errCode !== 0) {
+                if ($client->errCode !== SOCKET_EAGAIN && $client->errCode !== SOCKET_ETIMEDOUT && $client->errCode !== 0) {
                     $this->disconnectClient($id);
                 }
                 continue;

--- a/src/Listener/OnDisconnectListener.php
+++ b/src/Listener/OnDisconnectListener.php
@@ -6,10 +6,13 @@ namespace Nashgao\MQTT\Listener;
 
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
+use Nashgao\MQTT\Config\TopicConfig;
 use Nashgao\MQTT\Event\OnDisconnectEvent;
+use Nashgao\MQTT\Event\SubscribeEvent;
 use Nashgao\MQTT\Metrics\ConnectionMetrics;
 use Nashgao\MQTT\Metrics\ErrorMetrics;
 use Nashgao\MQTT\Metrics\ValidationMetrics;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Simps\MQTT\Hex\ReasonCode;
@@ -27,6 +30,8 @@ class OnDisconnectListener implements ListenerInterface
 
     private ValidationMetrics $validationMetrics;
 
+    private ?EventDispatcherInterface $dispatcher;
+
     private array $disconnectionReasons = [];
 
     private array $poolDisconnections = [];
@@ -36,12 +41,14 @@ class OnDisconnectListener implements ListenerInterface
         ?LoggerInterface $logger = null,
         ?ConnectionMetrics $connectionMetrics = null,
         ?ErrorMetrics $errorMetrics = null,
-        ?ValidationMetrics $validationMetrics = null
+        ?ValidationMetrics $validationMetrics = null,
+        ?EventDispatcherInterface $dispatcher = null
     ) {
         $this->logger = $logger ?? $stdoutLogger ?? new NullLogger();
         $this->connectionMetrics = $connectionMetrics ?? new ConnectionMetrics();
         $this->errorMetrics = $errorMetrics ?? new ErrorMetrics();
         $this->validationMetrics = $validationMetrics ?? new ValidationMetrics();
+        $this->dispatcher = $dispatcher;
     }
 
     public function listen(): array
@@ -65,6 +72,9 @@ class OnDisconnectListener implements ListenerInterface
 
             // Log the disconnect event with comprehensive details
             $this->logDisconnectEvent($event);
+
+            // Dispatch resubscription to restore topic subscriptions immediately
+            $this->dispatchResubscription($event);
 
             // Record successful processing
             $this->validationMetrics->recordValidation(
@@ -225,9 +235,56 @@ class OnDisconnectListener implements ListenerInterface
         ?LoggerInterface $logger = null,
         ?ConnectionMetrics $connectionMetrics = null,
         ?ErrorMetrics $errorMetrics = null,
-        ?ValidationMetrics $validationMetrics = null
+        ?ValidationMetrics $validationMetrics = null,
+        ?EventDispatcherInterface $dispatcher = null
     ): self {
-        return new self($stdoutLogger, $logger, $connectionMetrics, $errorMetrics, $validationMetrics);
+        return new self($stdoutLogger, $logger, $connectionMetrics, $errorMetrics, $validationMetrics, $dispatcher);
+    }
+
+    /**
+     * Dispatch resubscription event to restore topic subscriptions after disconnect.
+     *
+     * Converts raw subscribe config from ClientConfig into TopicConfig objects
+     * and dispatches a SubscribeEvent so the SubscribeListener re-subscribes
+     * all topics on the reconnected connection.
+     */
+    private function dispatchResubscription(OnDisconnectEvent $event): void
+    {
+        if ($this->dispatcher === null) {
+            $this->logger->debug('No event dispatcher available, skipping resubscription dispatch');
+            return;
+        }
+
+        if (empty($event->clientConfig->subscribe)) {
+            $this->logger->debug('No subscribe configuration available for resubscription', [
+                'pool_name' => $event->poolName,
+            ]);
+            return;
+        }
+
+        try {
+            /** @var TopicConfig[] $topicConfigs */
+            $topicConfigs = array_map(
+                static fn(array $config): TopicConfig => new TopicConfig($config),
+                $event->clientConfig->subscribe
+            );
+
+            $this->dispatcher->dispatch(new SubscribeEvent(
+                $event->poolName,
+                $topicConfigs
+            ));
+
+            $this->logger->info('Dispatched resubscription after disconnect', [
+                'pool_name' => $event->poolName,
+                'topic_count' => count($topicConfigs),
+                'disconnect_code' => $event->code,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to dispatch resubscription', [
+                'pool_name' => $event->poolName,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- **fix**: QoS 1/2 ACKs (PUBACK, PUBREC, PUBCOMP) and keepalive ping no longer consume the next incoming MQTT packet via internal `recv()` — root cause of QoS 2 inflight filling to 32 and stalling
- **fix**: DebugTapServer handles `SOCKET_ETIMEDOUT` (110) in recv loop — Swoole coroutine sockets return 110 not `SOCKET_EAGAIN` (11) on timeout
- **feat**: OnDisconnectListener dispatches `SubscribeEvent` on disconnect for immediate topic resubscription, eliminating up to 2-minute delay from the periodic `OnSubscribeListener` timer

## Changes

### `src/ClientProxy.php`
- `send($data, false)` for PUBACK, PUBREC, PUBCOMP — prevents `send()` from consuming the next packet
- `ping(false)` for keepalive heartbeat — same fix

### `src/Debug/DebugTapServer.php`  
- Added `SOCKET_ETIMEDOUT` to acceptable error codes in client recv loop
- `@chmod` to suppress warning on socket file permission

### `src/Listener/OnDisconnectListener.php`
- Added `EventDispatcherInterface` (nullable constructor param, matching existing DI pattern)
- New `dispatchResubscription()` method: converts raw `ClientConfig::$subscribe` arrays to `TopicConfig[]`, dispatches `SubscribeEvent` with pool name and topic configs
- Updated `create()` static factory to include dispatcher

## Testing

All fixes verified on `space-oracle-test` server (`140.238.200.218`) with live EMQX MQTT traffic:
- QoS 2 handshake completing successfully (PUBREC → PUBREL → PUBCOMP)
- DebugTap clients staying connected without ETIMEDOUT disconnections  
- PiEntity pool populating (99+ entities from live traffic)